### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: CI
 
 on:
   push:
@@ -11,8 +11,6 @@ on:
 
 jobs:
   build:
-
-    #runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -20,30 +18,51 @@ jobs:
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: true
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Build check
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install wheel
-        python -m pip install flake8 pytest numpy cython
-        
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        
-        # To generate version.py and compiled utils_c
-        python setup.py build
-        cp build/lib*/grizli/utils_c/*so grizli/utils_c/
-        
+        pip install build twine
+        python -m build .
+        python -m twine check dist/*
+  
+  codestyle:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10']
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install package
+      run: |
+        pip install flake8
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude "scripts* build* docs* dist* examples*"
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude "scripts* eazy-photoz* astropy_helpers*"
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10']
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install package
+      run: |
+        pip install -e .
+        pip install pytest
     - name: Test with pytest
       run: |
         pytest --disable-warnings

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,8 +61,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: |
-        pip install -e .
-        pip install pytest
+        pip install -e .[test]
     - name: Test with pytest
       run: |
         pytest --disable-warnings

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,14 +25,14 @@ jobs:
     - name: Build check
       run: |
         pip install build twine
-        python -m build .
-        python -m twine check dist/*
+        python -m build
+        python -m twine check --strict dist/*
   
   codestyle:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.10']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
         pip install flake8
     - name: Lint with flake8
       run: |
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude "scripts* build* docs* dist* examples*"
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
   test:
     runs-on: ${{ matrix.os }}
@@ -64,4 +64,4 @@ jobs:
         pip install -e .[test]
     - name: Test with pytest
       run: |
-        pytest --disable-warnings
+        pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-# astropy*helpers
 grizli/data/db.local.yml
 grizli/utils_c/*.c
+grizli/version.py
 
 *notes
 PipelineTest/*

--- a/grizli/__init__.py
+++ b/grizli/__init__.py
@@ -1,9 +1,7 @@
 """
 Pipeline for flexible modeling and extration of slitless spectroscopy
 """
-#__version__ = "0.1.1.dev"
-#from .version import __version__
-from .version import __version__, __long_version__, __version_hash__
+from .version import __version__
 
 import os
 
@@ -24,26 +22,5 @@ import os
 # Test that GRIZLI system variable is set
 if os.getenv('GRIZLI') is None:
     GRIZLI_PATH = os.path.join(os.path.dirname(__file__), 'data/')
-
-#     print("""
-# Warning: $GRIZLI system variable not set and will default to {0}.
-# Grizli will need to find the configuration files in $GRIZLI/CONF.
-#     """.format(GRIZLI_PATH))
-    #GRIZLI_PATH = '/usr/local/share/grizli_home'
 else:
     GRIZLI_PATH = os.getenv('GRIZLI')
-
-# try:
-#     import sep
-# except:
-#     print("""
-# Couldn't `import sep`.  SExtractor replaced with SEP
-# in April 2018.  Install with `pip install sep`.
-# """)
-
-# try:
-#     import tristars
-# except:
-#     print("""
-# Couldn't `import tristars`.  Get it from https://github.com/gbrammer/tristars to enable improved blind astrometric matching with triangle asterisms.
-# """)

--- a/grizli/fitting.py
+++ b/grizli/fitting.py
@@ -355,7 +355,7 @@ def run_all(id, t0=None, t1=None, fwhm=1200, zr=[0.65, 1.6], dz=[0.004, 0.0002],
     from grizli.multifit import MultiBeam
 
     #from . import __version__ as grizli__version
-    from .version import __long_version__ as grizli__version
+    from .version import __version__ as grizli__version
     from .pipeline import summary
 
     if get_dict:

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -382,7 +382,7 @@ class GrismDisperser(object):
 
         conf_sens = self.conf.sens[self.beam]
         if self.MW_F99 is not None:
-            MWext = 10**(-0.4*(self.MW_F99(conf_sens['WAVELENGTH']*u.AA)))
+            MWext = 10**(-0.4*(self.MW_F99(conf_sens['WAVELENGTH'])))
         else:
             MWext = 1.
 
@@ -504,7 +504,7 @@ class GrismDisperser(object):
 
         conf_sens = self.conf.sens[self.beam]
         if self.MW_F99 is not None:
-            MWext = 10**(-0.4*(self.MW_F99(conf_sens['WAVELENGTH']*u.AA)))
+            MWext = 10**(-0.4*(self.MW_F99(conf_sens['WAVELENGTH'])))
         else:
             MWext = 1.
 

--- a/grizli/stack.py
+++ b/grizli/stack.py
@@ -2,7 +2,6 @@
 Utilities for fitting stacked (drizzled) spectra
 """
 from collections import OrderedDict
-from imp import reload
 
 import astropy.io.fits as pyfits
 import astropy.units as u

--- a/grizli/tests/test_autoscript.py
+++ b/grizli/tests/test_autoscript.py
@@ -5,8 +5,8 @@ import glob
 
 import numpy as np
 
-from .. import utils
-from ..pipeline import auto_script
+from grizli import utils
+from grizli.pipeline import auto_script
 
 class UtilsTester(unittest.TestCase):
     

--- a/grizli/tests/test_cutils.py
+++ b/grizli/tests/test_cutils.py
@@ -1,8 +1,10 @@
 import unittest
 
 import numpy as np
-from .. import utils
-from ..utils_c import interp
+
+from grizli import utils
+from grizli.utils_c import interp
+
 
 def test_cinterp():
     """
@@ -11,7 +13,7 @@ def test_cinterp():
     xarr = np.array([0.0,1.0,2.0])
     yarr = np.array([0.0,1.0,0.0])
     result = interp.interp_c(np.array([0.5]), xarr, yarr)
-    assert(np.allclose(result, 0.5))
+    assert np.allclose(result, 0.5)
 
 
 def test_cinterp_conserve():
@@ -27,8 +29,8 @@ def test_cinterp_conserve():
     
     ylr = interp.interp_conserve_c(xlr, xarr, yarr)
     
-    assert(np.allclose(np.trapz(ylr, xlr), np.trapz(yarr, xarr)))
+    assert np.allclose(np.trapz(ylr, xlr), np.trapz(yarr, xarr))
     
     ylr_slow = interp.interp_conserve(xlr, xarr, yarr)
-    assert(np.allclose(np.trapz(ylr_slow, xlr), np.trapz(yarr, xarr)))
+    assert np.allclose(np.trapz(ylr_slow, xlr), np.trapz(yarr, xarr))
     

--- a/grizli/tests/test_fits.py
+++ b/grizli/tests/test_fits.py
@@ -8,11 +8,10 @@ import glob
 import unittest
 
 import numpy as np
-from .. import utils, prep, multifit, fitting, GRIZLI_PATH
+from grizli import utils, prep, multifit, fitting, GRIZLI_PATH
 
 
 class FittingTools(unittest.TestCase):
-    #pass
     
     def test_config(self):
         """
@@ -32,9 +31,8 @@ class FittingTools(unittest.TestCase):
             files = glob.glob(f'{conf_path}/*')
             print('Files: ', '\n'.join(files))
 
-        assert(os.path.exists(os.path.join(conf_path,
-                              'G141.F140W.V4.32.conf')))
-        return True
+        assert os.path.exists(os.path.join(conf_path,
+                              'G141.F140W.V4.32.conf'))
             
     def test_multibeam(self):
         """
@@ -42,17 +40,17 @@ class FittingTools(unittest.TestCase):
         """
         path = os.path.dirname(utils.__file__)
         print(path)
-        beams_file = path+'/tests/data/j033216m2743_00152.beams.fits'
+        beams_file = os.path.join(path, 'tests', 'data', 'j033216m2743_00152.beams.fits')
         mb = multifit.MultiBeam(beams_file, group_name='j033216m2743',
                                 MW_EBV=-1, fcontam=0.1, sys_err=0.03)
     
-        assert(mb.N == 2)
-        assert('G102' in mb.PA)
+        assert mb.N == 2
+        assert 'G102' in mb.PA
         
         expn, expt = mb.compute_exptime()
-        assert(np.allclose(expt['G102'], 1102.93, rtol=1.e-2))
+        assert np.allclose(expt['G102'], 1102.93, rtol=1.e-2)
         
-        _ = mb.compute_model()
+        mb.compute_model()
         
         spec = mb.oned_spectrum()
         
@@ -61,18 +59,15 @@ class FittingTools(unittest.TestCase):
         Can we run the full fit?
         """
         path = os.path.dirname(utils.__file__)
-        data_path = path +'/tests/data/'
+        data_path = os.path.join(path, 'tests', 'data')
     
         res = fitting.run_all_parallel(152, zr=[1.7, 1.8], verbose=True,
-                                 root=data_path+'j033216m2743',
-                                 args_file=data_path+'fit_args.npy', 
+                                 root=os.path.join(data_path, 'j033216m2743'),
+                                 args_file=os.path.join(data_path, 'fit_args.npy'), 
                                  get_output_data=True, 
                                  protect=False)
         
-        if len(res) > 3:
-             assert(np.allclose(res[2].meta['z_map'][0], 1.7429, rtol=1.e-2))
-        else:
-            raise ValueError('Something went wrong with run_all_parallel')
+        assert np.allclose(res[2].meta['z_map'][0], 1.7429, rtol=1.e-2)
             
         # Clean up
         files = glob.glob('j033216m2743_00152*')

--- a/grizli/tests/test_grismconf.py
+++ b/grizli/tests/test_grismconf.py
@@ -4,8 +4,9 @@ import os
 
 import numpy as np
 
-from .. import grismconf as grizliconf
-from .. import GRIZLI_PATH
+from grizli import grismconf as grizliconf
+from grizli import GRIZLI_PATH
+
 
 def test_transform():
     """

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -8,8 +8,9 @@ import numpy as np
 import astropy.io.fits as pyfits
 import logging
 
-from .. import prep, utils, multifit, GRIZLI_PATH, jwst_utils
-from ..pipeline import auto_script
+from grizli import prep, utils, multifit, GRIZLI_PATH, jwst_utils
+from grizli.pipeline import auto_script
+
 
 def set_crds(path='crds_cache'):
     """

--- a/grizli/tests/test_utils.py
+++ b/grizli/tests/test_utils.py
@@ -1,7 +1,9 @@
 import unittest
 
 import numpy as np
-from .. import utils
+
+from grizli import utils
+
 
 class UtilsTester(unittest.TestCase):
     def test_log_zgrid(self):

--- a/grizli/utils_c/disperse.pyx
+++ b/grizli/utils_c/disperse.pyx
@@ -40,8 +40,8 @@ def disperse_grism_object(np.ndarray[FTYPE_t, ndim=2] flam,
     ----------
     xxx
     """
-    cdef int i,j,k1,k2
-    cdef unsigned int nk,nl,k,shx,shy
+    cdef int i,j,k1,k2,nl
+    cdef unsigned int nk,k,shx,shy
     cdef double fl_ij
     
     nk = len(idxl)

--- a/grizli/utils_c/interp.pyx
+++ b/grizli/utils_c/interp.pyx
@@ -492,7 +492,7 @@ def run_nmf(np.ndarray[DTYPE_t, ndim=1] flux, np.ndarray[DTYPE_t, ndim=1] varian
             coeffs[i] = 0.
             
     itcount=0;
-    while (tol>toler) & (itcount<MAXITER):
+    while (tol>toler) & (long(itcount)<MAXITER):
         tolnum=0.
         toldenom = 0.
         tol=0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-# These are the assumed default build requirements from pip:
-# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "wheel", "numpy", "cython"]
+requires = ["setuptools>=43.0.0", "setuptools_scm[toml]>=6.2", "wheel",
+            "numpy", "cython"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "grizli/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=43.0.0", "setuptools_scm[toml]>=6.2", "wheel",
-            "numpy", "cython"]
+            "oldest-supported-numpy", "cython"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,19 +16,29 @@ classifiers=
         Intended Audience :: Science/Research
         Topic :: Scientific/Engineering :: Astronomy
 
-# Options specific to Astropy-affiliated packages
-# See below for more info :
-# https://docs.astropy.org/projects/package-template/en/latest/options.html
-# edit_on_github_extension = False
-# github_project = gbrammer/grizli
-
 [options]
 python_requires = >=3.7
 install_requires = 
     astropy
+    drizzlepac
     numpy
+    peakutils
+    scipy
+    specutils
     sregion
+    stwcs
 packages = find_namespace:
+
+[options.extras_require]
+test =
+    pytest>=5.1
+    flake8
+jwst =
+    jwst
+hst =
+    hstcal
+aws =
+    boto3
 
 [options.package_data]
 grizli.data =
@@ -60,7 +70,6 @@ show_response = 1
 [tool:pytest]
 minversion = 5.0
 norecursedirs = build docs/_build
-doctest_plus = enabled
 testpaths = 
     grizli/tests
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ author = G. Brammer
 author_email = gbrammer@gmail.com
 description = Grism redshift and line analysis software
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/gbrammer/grizli
 license = MIT
 license_files = LICENSE.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,12 +22,15 @@ python_requires = >=3.7
 install_requires = 
     astropy
     drizzlepac
+    mastquery
     numpy
     peakutils
     scipy
+    sep
     specutils
     sregion
     stwcs
+    tqdm
 packages = find_namespace:
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ grizli.data.templates.fsps =
     *
 grizli.data.templates.stars =
     *
+grizli.tests.data =
+    *
 
 [build_sphinx]
 source_dir = docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.7
 install_requires = 
     astropy
     numpy
-    sregion>=1.0
+    sregion
 packages = find_namespace:
 
 [options.package_data]
@@ -37,13 +37,6 @@ data =
     templates/*
     templates/stars/*
     templates/fsps/*
-
-# Below are now deprecated
-# See:
-# 1.) https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html
-# 2.) https://setuptools.pypa.io/en/latest/history.html#id621
-# zip_safe = False
-# use_2to3 = False
 
 [build_sphinx]
 source_dir = docs
@@ -60,18 +53,11 @@ upload_dir = docs/_build/html
 show_response = 1
 
 [tool:pytest]
-minversion = 3.0
-norecursedirs = build docs/_build astropy_helpers
+minversion = 5.0
+norecursedirs = build docs/_build
 doctest_plus = enabled
-addopts = -p no:warnings
 testpaths = 
     grizli/tests
 
 [flake8]
-exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py,docs/conf.py,setup.py
-
-[pycodestyle]
-exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py,docs/conf.py,setup.py
-
-[entry_points]
-astropy_package_template_example = packagename.example_mod:main
+exclude = *parsetab.py,conftest.py,docs/conf.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,17 @@ install_requires =
 packages = find_namespace:
 
 [options.package_data]
-data = 
+grizli.data =
+    *.yml
+    *.txt
+    *.fits
+    *.fits.gz
+grizli.data.templates =
     *
-    *fits.gz
-    templates/*
-    templates/stars/*
-    templates/fsps/*
+grizli.data.templates.fsps =
+    *
+grizli.data.templates.stars =
+    *
 
 [build_sphinx]
 source_dir = docs

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 import os
-import subprocess
 
 import numpy
 from setuptools import setup
 from setuptools.extension import Extension
+from Cython.Build import cythonize
 
 include_dirs = [numpy.get_include()]
 if os.name == 'nt':
@@ -28,5 +28,6 @@ extensions = [
                 define_macros=define_macros,
                 ),
     ]
+extensions = cythonize(extensions, language_level=3)
 
 setup(ext_modules=extensions)

--- a/setup.py
+++ b/setup.py
@@ -1,111 +1,32 @@
 #!/usr/bin/env python
-
-#from distutils.core import setup
-#from distutils.extension import Extension
-from setuptools import setup
-from setuptools.extension import Extension
-from setuptools.config import read_configuration
-
-#import ah_bootstrap
-#import builtins
-
+import os
 import subprocess
 
-import os
+import numpy
+from setuptools import setup
+from setuptools.extension import Extension
 
-try:
-    import numpy 
-    include_dirs = [numpy.get_include()]
-except ImportError:
-    include_dirs = []
-    
-try:
-    from Cython.Build import cythonize
-    USE_CYTHON = True
-except ImportError:
-    USE_CYTHON = False
-
-if not os.path.exists('grizli/utils_c/interp.pyx'):
-    USE_CYTHON = False
-    
-if USE_CYTHON:
-    cext = '.pyx'
-else:
-    cext = '.c'
-
-print('C extension: {0}'.format(cext))
-
+include_dirs = [numpy.get_include()]
 if os.name == 'nt':
     # Windows
-    extensions = [
-        Extension("grizli.utils_c.interp", ["grizli/utils_c/interp"+cext],
-            include_dirs = include_dirs),
-        
-        Extension("grizli.utils_c.disperse", ["grizli/utils_c/disperse"+cext],
-            include_dirs = include_dirs),
-    ]
+    libraries = None
 else:
     # Not windows
-    extensions = [
-        Extension("grizli.utils_c.interp", ["grizli/utils_c/interp"+cext],
-            include_dirs = include_dirs,
-            libraries=["m"]),
-        
-        Extension("grizli.utils_c.disperse", ["grizli/utils_c/disperse"+cext],
-            include_dirs = include_dirs,
-            libraries=["m"]),
-    ] 
+    libraries = ["m"]
+define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+extensions = [
+    Extension(name="grizli.utils_c.interp",
+                sources=["grizli/utils_c/interp.pyx"],
+                include_dirs=include_dirs,
+                libraries=libraries,
+                define_macros=define_macros,
+                ),
+    Extension(name="grizli.utils_c.disperse",
+                sources=["grizli/utils_c/disperse.pyx"],
+                include_dirs=include_dirs,
+                libraries=libraries,
+                define_macros=define_macros,
+                ),
+    ]
 
-#update version
-if os.path.exists('.git'):
-    args = 'git describe --tags'
-    p = subprocess.Popen(args.split(), stdout=subprocess.PIPE)
-    long_version = p.communicate()[0].decode("utf-8").strip()
-    spl = long_version.split('-')
-
-    if len(spl) == 3:
-        main_version = spl[0]
-        commit_number = spl[1]
-        version_hash = spl[2]
-        version = f'{main_version}.dev{commit_number}'
-    else:
-        version_hash = '---'
-        version = long_version
-
-    print('Git version: {0}'.format(version))
-else:
-    # e.g., on pip
-    version = long_version = version_hash = '1.3.2'
-
-# Manual version tag
-# version = '1.4.0' # New aws tools
-# version = '1.5.1' # bump for JWST
-# version = '1.6.0' # with MIRI sky flats and nircam wisp correction
-
-version_str =f"""# git describe --tags
-__version__ = "{version}"
-__long_version__ = "{long_version}"
-__version_hash__ = "{version_hash}" """
-
-fp = open('grizli/version.py','w')
-fp.write(version_str)
-fp.close()
-
-if USE_CYTHON:
-    extensions = cythonize(extensions, language_level="3")
-
-# Utility function to read the README file.
-# Used for the long_description.  It's nice, because now 1) we have a top level
-# README file and 2) it's easier to type in the README file than to put a raw
-# string in below ...
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-setup(
-    # See below for why download_url shouldn't be used moving forward:
-    # https://github.com/pypa/packaging.python.org/issues/293
-    # download_url = "https://github.com/gbrammer/grizli/tarball/{0}".format(version),
-    ext_modules = extensions,
-    # package_data={'grizli': ['data/*', 'data/*fits.gz', 'data/templates/*', 'data/templates/stars/*', 'data/templates/fsps/*']},
-    # scripts=['grizli/scripts/flt_info.sh'],
-)
+setup(ext_modules=extensions)


### PR DESCRIPTION
This PR does the following:

- makes sure package data in `grizli/data` and `grizli/tests/data` is included in both sdist and wheel
- fixes the cython compile under setuptools to work with modern `python -m build .` and by extension `pip install`
- uses `setuptools-scm` for versioning based on git tags
- adds `[test]`, `[hst]`, `[jwst]` and `[aws]` install extras
- divides the CI into 3 parts - build, code style, test - and updates them to use the modern build method
- fixes a bug in `grizli.fitting` found in the tests due to use of non-dimensionless units in an exponent.

Addresses #5