### PR TITLE
Update installation instructions

### DIFF
--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -85,15 +85,15 @@ libraries:
 ``lacosmicx``
 #############
 
-``lacosmicx`` is not required for running ``grizli``. If it is not installed, there will
-be no additional cosmic ray rejection performed. ``lacosmicx`` has been superseeded by 
-`astroscrappy <https://github.com/astropy/astroscrappy>`__
 `lacosmicx <https://github.com/cmccully/lacosmicx>`__ is a fast Python implementation of
 Pieter van Dokkum's `L.A.Cosmic <http://www.astro.yale.edu/dokkum/lacosmic/>`__
 (`2001PASP..113.1420V <http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software
 for identifying cosmic rays in single images. The image preparation wrapper scripts in
 `grizli.prep` run ``lacosmicx`` if a supplied list of direct or grism images contains
 only a single file. 
+
+``lacosmicx`` has been superseeded by 
+`astroscrappy <https://github.com/astropy/astroscrappy>`__.
 
 - Change directories to the location where the ``grizli`` repo was cloned before:
 

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -1,3 +1,19 @@
+Installation
+~~~~~~~~~~~~~~
+
+The easiest way to install the latest ``grizli`` release into a fresh virtualenv or conda environment is:
+
+.. code-block:: bash
+
+   pip install grizli
+   pip install pyregion
+   pip install git+https://github.com/gbrammer/tristars
+
+If you are installing ``grizli`` for the first time, make sure to also set up directories and download 
+reference files: :ref:`Set up directories and fetch additional files`
+
+More detailed instructions are available below.
+
 Development Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -63,6 +79,8 @@ or
 
 To minimize conflict of dependencies, install only the ones that you need. 
 
+.. additional
+
 Additional dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -71,8 +89,8 @@ need to be installed separately:
 
 .. code-block:: bash
   
-  pip install git+https://github.com/gbrammer/tristars
   pip install pyregion
+  pip install git+https://github.com/gbrammer/tristars
   
 If you will be working with HST data, you will also need the following two 
 libraries:
@@ -105,7 +123,7 @@ only be done once, or after updating the repository:
 .. code-block:: bash
 
     pytest
-    
+        
 Set up directories and fetch additional files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -170,7 +188,7 @@ Installing ``grizli`` from source
 If you need to install ``grizli` form a specific branch or need an editable version 
 of the library, you can do this directly from the repository.
 
-- Create a dedicated environment. See instructions above. 
+- Create a dedicated environment. See instructions above.
 - Change into a directory where the ``grizli`` repo will live. 
 - Fetch the ``grizli`` repo and change into the newly cloned directory:
 

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -15,7 +15,7 @@ the current test suite does not yet test all of the full functionality of the co
 Setting up a Local Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We recommend that ``grizli`` be installed in a new vitrual environment to minimize conflicts 
+We recommend that ``grizli`` be installed in a new virtual environment to minimize conflicts
 with dependencies for other packages. Possible virtual environment managers are ``conda``, ``venv``, ``pyenv``, etc.
 Here we give example with setting up a ``conda`` environment. 
 

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -161,46 +161,11 @@ only be done once, or after updating the
 .. code-block:: bash
 
     pytest
-
-Installing ``grizli`` from source
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you need to install ``grizli` form a specific branch or need an editable version 
-of the library, you can do this directly from the repository.
-
-- Change into a directory where the ``grizli`` repo will live. Instead of
-  ``/usr/local/share/python``, this could even be some other location such as ``/tmp/``:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python
-
-- Fetch the ``grizli`` repo and change into the newly cloned directory:
-
-.. code-block:: bash
-
-    git clone https://github.com/gbrammer/grizli.git
-    cd grizli
-
-- Compile and install the ``grizli`` module. This only needs to be done once (on initial
-  ``clone``), or after updating the repository (e.g., after a ``git pull``).
-
-.. code-block:: bash
-
-   pip install --editable .
-   
-Or to install the optional dependencies:
-
-.. code-block:: bash
-
-   pip install --editable ".[jwst,test]"
-
-
-See above for the additional dependencies that need to be installed.
-
+    
 Set up directories and fetch additional files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-- ``grizli`` requires a few environmental variables to be set that point to the
+
+ ``grizli`` requires a several environmental variables to be set that point to the
   directory location of configuration files. The ``export`` lines below can be put into
   the ``~/.bashrc`` or ``~/.bash_profile`` setup files so that the system variables are
   set automatically when you start a new terminal/shell session.
@@ -255,29 +220,50 @@ Set up directories and fetch additional files
     pip install '.[test]'
     pytest
 
+Installing ``grizli`` from source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need to install ``grizli` form a specific branch or need an editable version 
+of the library, you can do this directly from the repository.
+
+- Change into a directory where the ``grizli`` repo will live. Instead of
+  ``/usr/local/share/python``, this could even be some other location such as ``/tmp/``:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python
+
+- Fetch the ``grizli`` repo and change into the newly cloned directory:
+
+.. code-block:: bash
+
+    git clone https://github.com/gbrammer/grizli.git
+    cd grizli
+
+- Compile and install the ``grizli`` module. This only needs to be done once (on initial
+  ``clone``), or after updating the repository (e.g., after a ``git pull``).
+
+.. code-block:: bash
+
+   pip install --editable .
+   
+Or to install the optional dependencies:
+
+.. code-block:: bash
+
+   pip install --editable ".[jwst,test]"
+
+
+See above for the additional dependencies that need to be installed.
+
 Using HST Files Staged on AWS
-#############################
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``grizli`` can automatically pull FITS files from the public AWS S3 bucket mirror of the
 *HST* archive, which can be useful when running the full *HST* reduction pipeline. This
-requires that the AWS command line tools and the ``boto3`` module be installed:
-
-- Change directories into the location where the ``grizli`` repo was cloned:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python/grizli # location from before, where grizli repo was cloned
-
-- Activate the ``conda`` environment:
-
-.. code-block:: bash
-
-    conda activate grizli39 # or whatever was chosen before
+requires that the AWS command line tools and the ``boto3`` and ``awscli`` modules be installed:
 
 .. code-block:: bash
 
     # Put your AWS credentials, etc. in ~/.aws 
-    pip install '.[aws]'
-
-
-
+    pip install grizli '.[aws]'

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -1,199 +1,248 @@
-Installation instructions
-
 Python Environment
 ------------------
 
 `Grizli` has been developed within a `miniconda
 <https://docs.conda.io/en/latest/miniconda.html>`_ Python environment. Module
-dependencies, including general utilities like `numpy`, `scipy`, and
-`matplotlib` and astronomy tools like `astropy` and specific software for
-dealing with space-telescope data (`stsci.tools`, `drizzlepac`, etc.) are
-installed using the provided ``requirements.txt`` file (see below). Most
-development is done in a ``python 3.9`` environment on a MacBook Pro running
-Mojave 10.14.6.  The basic build is tested in (Linux) python ``3.7``,
-``3.8`` and ``3.9`` with the `GitHub actions <https://github.com/gbrammer/grizli/actions>`_ continuous integration (CI)
-tools, but the current test suite does not yet test all of the full
-functionality of the code.
+dependencies, including general utilities like `numpy`, `scipy`, `matplotlib`, 
+astronomy tools like `astropy` and specific software for dealing with space-telescope
+data (`stsci.tools`, `drizzlepac`, etc.) are all installed using the standard 
+``pip install`` method (see below). Most development is done in a ``python 3.9``
+environment on a MacBook Pro running Mojave 10.14.6.  The basic build is tested in
+(Linux) python ``3.7``, ``3.8`` and ``3.9`` with the `GitHub actions
+<https://github.com/gbrammer/grizli/actions>`_ continuous integration (CI) tools, but
+the current test suite does not yet test all of the full functionality of the code.
 
-Preferred installation with conda/pip
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The environment can be installed with ``pip`` and the `requirements.txt <https://github.com/gbrammer/grizli/blob/master/requirements.txt>`_ file, which was added in 2021 to enable the github "actions" CI testing environment (migrated from `travis-ci.org <https://travis-ci.org>`_).  The instructions below assume you have `conda` installed, e.g., with `miniconda
-<https://docs.conda.io/en/latest/miniconda.html>`_. 
-
-.. code:: bash
-    
-    # Generate a conda environment named "grizli39" or anything else
-    # This will just provide the base python distribution (incl. pip)
-    conda create -n grizli39 python=3.9 pip numpy cython
-            
-    # Activate the environment.  This needs to be done each time you 
-    # start a new terminal, or put it in ~/.bashrc
-    conda activate grizli39
-
-    # or some other location, even /tmp/
-    cd /usr/local/share/python 
-
-    # Fetch the grizli repo
-    git clone https://github.com/gbrammer/grizli.git
-    cd grizli
-        
-    # Compile and install the grizli module.  Only needs to be done
-    # once or after updating the repository (e.g., with `git pull`).
-    # "--editable" builds the cython extensions needed for pytest
-    pip install --editable . -r requirements.txt
-    
-    # One last dependency that doesn't install with pip and is needed
-    # for the WFC3/IR pipeline calwf3
-    conda install hstcal
-    
-    # Run basic tests with pytest *after downloading config files as below*
-    pip install pytest
-    pytest
-    
-If you are planning to run simultaneous fits to grism spectra plus photometry using the `eazy-py <https://github.com/gbrammer/eazy-py>`_ connection, install `eazy-py` from the repository to ensure that you get its dependencies.
-
-.. code:: bash
-
-    cd /usr/local/share/python # location from above
-    conda activate grizli39 # or whatever was chosen above
-    
-    # Fetch the eazy-py repo
-    git clone --recurse-submodules https://github.com/gbrammer/eazy-py.git
-    cd eazy-py
-    
-    # Only needs to be done once or after updating the repository.
-    pip install . -r requirements.txt
-
-    # Run basic tests with pytest
-    # (pysynphot failure is not critical)
-    pytest
-    
-Once you've built the code, proceed to `Set up directories and fetch config files`_.
-
-Installation with conda and `environment.yml`
+Preferred installation with ``conda``/``pip``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. note:: 
+The environment can be installed with ``pip``.  The instructions below assume
+you have ``conda`` installed, e.g., with `miniconda
+<https://docs.conda.io/en/latest/miniconda.html>`_. 
 
-    As of May 2021 the conda/pip installation above is favored since the CI
-    tests were migrated from travis to GitHub actions, which are run on each
-    push to the repository.
+Set up a ``conda`` environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-An `environment.yml <https://github.com/gbrammer/grizli/blob/master/environment.yml>`__ file is included with the `~grizli` distribution to 
-provide an automatic way of installing the required dependencies, getting
-them from `conda`, `pip`, and directly from `github` as necessary.  To use 
-this file, do the following
+- Generate a ``conda`` environment named ``grizli39`` (or anything else you prefer).
+  This will just provide the base Python distribution (along with ``pip``):
 
-.. code:: bash
+.. code-block:: bash
 
-    cd /usr/local/share/python # or some other location, even /tmp/
+    conda create --name grizli39 python=3.9
 
-    # Fetch the grizli repo
-    git clone https://github.com/gbrammer/grizli.git
-    cd grizli
-    
-    # Generate a conda environment named "grizli39" or anything else
-    # (Note environment_min.yml renamed to environment.yml for >0.10.0)
-    conda env create -f environment.yml -n grizli39
-            
-    # Activate the environment.  This needs to be done each time you 
-    # start a new terminal, or put it in ~/.bashrc
+- Activate the environment. If you chose a name other than ``grizli39``,
+  substitute that below:
+
+.. code-block:: bash
+
     conda activate grizli39
-    
-    # Compile and install the grizli module.  Only needs to be done
-    # once or after updating the repository.
-    python setup.py install 
-
-Manual installation of dependencies
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There are a few additional modules that `grizli` may use but that aren't explicitly listed in the `requirements.txt <https://github.com/gbrammer/grizli/blob/master/requirements.txt>`_ file.   
-
-**Amazon Web Services** - If you're running the full *HST* reduction pipeline with `grizli`, the code can automatically pull FITS files from the public AWS S3 bucket mirror of the archive. This requires the AWS command line tools and the `boto3` module:
-
-    .. code:: bash
-
-        # Put your AWS credentials, etc. in ~/.aws 
-        pip install awscli
-        pip install boto3    
-
-`lacosmicx <https://github.com/cmccully/lacosmicx>`__ - Fast Python
-implementation of Pieter van Dokkum's `L.A.Cosmic
-<http://www.astro.yale.edu/dokkum/lacosmic/>`__ (`2001PASP..113.1420V
-<http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software for
-identifying cosmic rays in single images. The image preparation wrapper
-scripts in `grizli.prep` run `lacosmicx` if a supplied list of direct or grism
-images contains only a single file.
-
-    .. code:: bash
-
-        git clone https://github.com/cmccully/lacosmicx.git
-        cd lacosmicx
-        python setup.py install
 
 .. note::
-    
+   The activation needs to be done *each time* you start a new terminal. Alternatively,
+   if you want it automatically done for every new terminal, you need to put the above
+   command in your ``~/.bashrc`` file.
+
+Download and set up ``grizli``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Change into a directory where the ``grizli`` repo will live. Instead of
+  ``/usr/local/share/python``, this could even be some other location such as ``/tmp/``:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python
+
+- Fetch the ``grizli`` repo and change into the newly cloned directory:
+
+.. code-block:: bash
+
+    git clone https://github.com/gbrammer/grizli.git
+    cd grizli
+
+- Compile and install the ``grizli`` module. This only needs to be done once (on initial
+  ``clone``), or after updating the repository (e.g., after a ``git pull``).
+
+.. code-block:: bash
+
+   pip install --editable .
+
+.. note::
+   The `--editable` flag builds the Cython extensions needed for `pytest`.
+
+- Install ``hstcal``, a dependency for the WFC3/IR pipeline ``calwf3``, that doesn't
+  install with ``pip``:
+
+.. code-block:: bash
+
+    conda install hstcal
+
+Set up directories and fetch additional files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- ``grizli`` requires a few environmental variables to be set that point to the
+  directory location of configuration files. The ``export`` lines below can be put into
+  the ``~/.bashrc`` or ``~/.bash_profile`` setup files so that the system variables are
+  set automatically when you start a new terminal/shell session.
+
+.. code-block:: bash
+
+    export GRIZLI="${HOME}/grizli" # or anywhere else
+    export iref="${GRIZLI}/iref/"  # for WFC3 calibration files
+    export jref="${GRIZLI}/jref/"  # for ACS calibration files
+
+- Create these directories, assuming that they do not already exist:
+
+.. code-block:: bash
+
+    mkdir $GRIZLI
+    mkdir $GRIZLI/CONF      # needed for grism configuration files
+    mkdir $GRIZLI/templates # for redshift fits
+    mkdir $iref
+    mkdir $jref
+
+- Download the calibration and configuration files not provided with the code
+  repository. Helper scripts are provided to download files that are currently
+  hard-coded:
+
+.. code-block:: python
+
+    >>> import grizli.utils
+    >>> # HST calibs to $iref/$iref
+    >>> # set get_acs=True below to get files necessary for G800L processing
+    >>> grizli.utils.fetch_default_calibs(get_acs=False)
+    >>> # config files to $GRIZLI/CONF
+    >>> # set get_jwst=True to get config files for jwst processing
+    >>> grizli.utils.fetch_config_files(get_acs=False, get_jwst=False)
+
+- The grism redshift fits require galaxy SED templates that are provided with the
+  repository but that need to be in a specific directory, ``$GRIZLI/templates``. This is
+  done so that users can modify/add templates in that directory without touching the
+  files in the repository itself. For default processing they can by symlinked from the
+  repository:
+
+.. code-block:: python
+
+    >>> import grizli.utils
+    >>> grizli.utils.symlink_templates(force=False)
+    >>> # Set force=True to symlink files even if they already exist in 
+    >>> # $GRIZLI/templates/.
+
+- Run basic tests with `pytest`:
+
+.. code-block:: bash
+
+    pip install '.[test]'
+    pytest
+
+Installing additional dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``eazy-py``
+###########
+
+If you are planning to run simultaneous fits to grism spectra plus photometry using the
+`eazy-py <https://github.com/gbrammer/eazy-py>`_ connection, install ``eazy-py`` from
+the repository to ensure that you get *its* dependencies.
+
+- Change directories to the location where the ``grizli`` repo was cloned before:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python # location from before
+
+- Activate the ``conda`` environment:
+
+.. code-block:: bash
+
+    conda activate grizli39 # or whatever was chosen before
+
+- Fetch the ``eazy-py`` repo, and change into its directory:
+
+.. code-block:: bash
+
+    git clone --recurse-submodules https://github.com/gbrammer/eazy-py.git
+    cd eazy-py
+  
+- Install the ``eazy-py`` module. This needs to only be done once, or after updating the
+  repository:
+
+.. code-block:: bash
+
+    pip install -r requirements.txt .
+
+- Run basic tests with ``pytest``. Note that the ``pysynphot`` failure is not critical:
+
+.. code-block:: bash
+
+    pytest
+ 
+
+Full *HST* reduction pipeline
+#############################
+
+``grizli`` can automatically pull FITS files from the public AWS S3 bucket mirror of the
+*HST* archive, which can be useful when running the full *HST* reduction pipeline. This
+requires that the AWS command line tools and the ``boto3`` module be installed:
+
+- Change directories into the location where the ``grizli`` repo was cloned:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python/grizli # location from before, where grizli repo was cloned
+
+- Activate the ``conda`` environment:
+
+.. code-block:: bash
+
+    conda activate grizli39 # or whatever was chosen before
+
+.. code-block:: bash
+
+    # Put your AWS credentials, etc. in ~/.aws 
+    pip install '.[aws]'
+
+
+``lacosmicx``
+#############
+
+`lacosmicx <https://github.com/cmccully/lacosmicx>`__ is a fast Python implementation of
+Pieter van Dokkum's `L.A.Cosmic <http://www.astro.yale.edu/dokkum/lacosmic/>`__
+(`2001PASP..113.1420V <http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software
+for identifying cosmic rays in single images. The image preparation wrapper scripts in
+`grizli.prep` run ``lacosmicx`` if a supplied list of direct or grism images contains
+only a single file.
+
+- Change directories to the location where the ``grizli`` repo was cloned before:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python # location from before
+
+- Activate the ``conda`` environment:
+
+.. code-block:: bash
+
+    conda activate grizli39 # or whatever was chosen before
+
+- Fetch the ``lacosmicx`` repo, and change into its directory:
+
+.. code-block:: bash
+
+    git clone https://github.com/cmccully/lacosmicx.git
+    cd lacosmicx
+
+- Install the package into the current environment:
+
+.. code-block:: bash
+
+    python setup.py install
+
+.. note::
     The `lacosmicx` dependency was removed from `environment.yml` file
     2019.12.31 because it was breaking on OSX Mojave 10.14.6 with a
     compilation error like `unsupported option '-fopenmp'`. The workaround
     below with the Homebrew version of `gcc` may work after verifying the
     correct path to the `gcc-8` executable:
     
-    .. code:: bash
-        
+    .. code-block:: bash
+
         brew install gcc
         CC=/usr/local/Cellar/gcc/10.2.0/bin/gcc-10 pip install git+https://github.com/cmccully/lacosmicx.git
-
-
-Set up directories and fetch config files
------------------------------------------
-`Grizli` requires a few environmental variables to be set that point to
-directory location of configuration files. The "`export`" lines below can be
-put into the *~/.bashrc* or *~/.bash_profile* setup files so that the system
-variables are set automatically when you start a new terminal/shell session.
-
-    .. code:: bash
-        
-        # Put these lines in ~/.bashrc
-        export GRIZLI="${HOME}/grizli" # or anywhere else
-        export iref="${GRIZLI}/iref/"  # for WFC3 calibration files
-        export jref="${GRIZLI}/jref/"  # for ACS calibration files
-        
-        # Make the directories, assuming they don't already exist
-        mkdir $GRIZLI
-        mkdir $GRIZLI/CONF      # needed for grism configuration files
-        mkdir $GRIZLI/templates # for redshift fits
-        
-        mkdir $iref
-        mkdir $jref
-
-There are configuration and reference files not provided with the code
-repository that must be downloaded. Helper scripts are provided to download
-files that are currently hard-coded:
-    
-    .. code:: python
-    
-        >>> import grizli.utils
-        >>> # HST calibs to iref/iref
-        >>> # set get_acs=True below to get files necessary for G800L processing
-        >>> grizli.utils.fetch_default_calibs(get_acs=False)
-        >>> # config files to $GRIZLI/CONF
-        >>> # set get_jwst=True to get config files for jwst processing
-        >>> grizli.utils.fetch_config_files(get_acs=False, get_jwst=False)
-    
-The grism redshift fits require galaxy SED templates that are provided with
-the repository but that need to be in a specific directory,
-`$GRIZLI/templates`. This is done so that users can modify/add templates in
-that directory without touching the files in the repository itself. For
-default processing they can by symlinked from the repository:
-
-    .. code:: python
-
-        >>> import grizli.utils
-        >>> grizli.utils.symlink_templates(force=False)
-        >>> # Set force=True to symlink files even if they already exist in 
-        >>> # $GRIZLI/templates/.
-
-
-
-

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -53,21 +53,21 @@ There are four available options for installing dependencies: ``jwst``, ``aws``,
 
 .. code-block:: bash
 
-  pip install grizli["jwst"]
+  pip install "grizli[jwst]"
 
 or 
 
 .. code-block:: bash
 
-  pip install grizli["jwst","test"]
+  pip install "grizli[jwst,test]"
 
 To minimize conflict of dependencies, install only the ones that you need. 
 
 Additional dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-``pip`` will install all needed dependencies with the exception of the following which
-which need to be installed separately:
+``pip`` will install all needed dependencies with the exception of the following which 
+need to be installed separately:
 
 .. code-block:: bash
   
@@ -81,56 +81,6 @@ libraries:
 
   conda install hstcal
   pip install git+https://github.com/gbrammer/reprocess_wfc3.git
-
-``lacosmicx``
-#############
-
-`lacosmicx <https://github.com/cmccully/lacosmicx>`__ is a fast Python implementation of
-Pieter van Dokkum's `L.A.Cosmic <http://www.astro.yale.edu/dokkum/lacosmic/>`__
-(`2001PASP..113.1420V <http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software
-for identifying cosmic rays in single images. The image preparation wrapper scripts in
-`grizli.prep` run ``lacosmicx`` if a supplied list of direct or grism images contains
-only a single file. 
-
-``lacosmicx`` has been superseeded by 
-`astroscrappy <https://github.com/astropy/astroscrappy>`__.
-
-- Change directories to the location where the ``grizli`` repo was cloned before:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python # location from before
-
-- Activate the ``conda`` environment:
-
-.. code-block:: bash
-
-    conda activate grizli39 # or whatever was chosen before
-
-- Fetch the ``lacosmicx`` repo, and change into its directory:
-
-.. code-block:: bash
-
-    git clone https://github.com/cmccully/lacosmicx.git
-    cd lacosmicx
-
-- Install the package into the current environment:
-
-.. code-block:: bash
-
-    python setup.py install
-
-.. note::
-    The `lacosmicx` dependency was removed from `environment.yml` file
-    2019.12.31 because it was breaking on OSX Mojave 10.14.6 with a
-    compilation error like `unsupported option '-fopenmp'`. The workaround
-    below with the Homebrew version of `gcc` may work after verifying the
-    correct path to the `gcc-8` executable:
-    
-    .. code-block:: bash
-
-        brew install gcc
-        CC=/usr/local/Cellar/gcc/10.2.0/bin/gcc-10 pip install git+https://github.com/cmccully/lacosmicx.git
         
 ``eazy-py``
 ###########
@@ -139,16 +89,10 @@ If you are planning to run simultaneous fits to grism spectra plus photometry us
 `eazy-py <https://github.com/gbrammer/eazy-py>`_ connection, install ``eazy-py`` from
 the repository to ensure that you get *its* dependencies.
 
-- Change directories to the location where the ``grizli`` repo was cloned before:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python # location from before
-    conda activate grizli39 # or whatever was chosen before
+- Change directories to the location where you store code locally and activate the environment.
 
 - Fetch the ``eazy-py`` repo, change into its directory and install it. This needs to 
-only be done once, or after updating the
-  repository:
+only be done once, or after updating the repository:
 
 .. code-block:: bash
 
@@ -156,7 +100,7 @@ only be done once, or after updating the
     cd eazy-py
     pip install -r requirements.txt .
 
-- Run basic tests with ``pytest``. Note that the ``pysynphot`` failure is not critical:
+- Optional: Run basic tests with ``pytest``. Note that the ``pysynphot`` failure is not critical:
 
 .. code-block:: bash
 
@@ -165,10 +109,10 @@ only be done once, or after updating the
 Set up directories and fetch additional files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
- ``grizli`` requires a several environmental variables to be set that point to the
-  directory location of configuration files. The ``export`` lines below can be put into
-  the ``~/.bashrc`` or ``~/.bash_profile`` setup files so that the system variables are
-  set automatically when you start a new terminal/shell session.
+``grizli`` requires a several environmental variables to be set that point to the
+directory location of configuration files. The ``export`` lines below can be put into
+the ``~/.bashrc`` or ``~/.bash_profile`` setup files so that the system variables are
+set automatically when you start a new terminal/shell session.
 
 .. code-block:: bash
 
@@ -217,7 +161,7 @@ Set up directories and fetch additional files
 
 .. code-block:: bash
 
-    pip install '.[test]'
+    pip install ".[test]"
     pytest
 
 Installing ``grizli`` from source
@@ -226,13 +170,8 @@ Installing ``grizli`` from source
 If you need to install ``grizli` form a specific branch or need an editable version 
 of the library, you can do this directly from the repository.
 
-- Change into a directory where the ``grizli`` repo will live. Instead of
-  ``/usr/local/share/python``, this could even be some other location such as ``/tmp/``:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python
-
+- Create a dedicated environment. See instructions above. 
+- Change into a directory where the ``grizli`` repo will live. 
 - Fetch the ``grizli`` repo and change into the newly cloned directory:
 
 .. code-block:: bash
@@ -240,18 +179,19 @@ of the library, you can do this directly from the repository.
     git clone https://github.com/gbrammer/grizli.git
     cd grizli
 
+- If you are installing from a branch, checkout the branch.
 - Compile and install the ``grizli`` module. This only needs to be done once (on initial
   ``clone``), or after updating the repository (e.g., after a ``git pull``).
 
 .. code-block:: bash
 
-   pip install --editable .
+   pip install -e .
    
-Or to install the optional dependencies:
+The ``-e`` flag stands for ``editable``. Or to install the optional dependencies:
 
 .. code-block:: bash
 
-   pip install --editable ".[jwst,test]"
+   pip install -e ".[jwst,test]"
 
 
 See above for the additional dependencies that need to be installed.
@@ -266,4 +206,4 @@ requires that the AWS command line tools and the ``boto3`` and ``awscli`` module
 .. code-block:: bash
 
     # Put your AWS credentials, etc. in ~/.aws 
-    pip install grizli '.[aws]'
+    pip install grizli ".[aws]"

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -1,5 +1,5 @@
-Python Environment
-------------------
+Development Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 `Grizli` has been developed within a `miniconda
 <https://docs.conda.io/en/latest/miniconda.html>`_ Python environment. Module
@@ -12,15 +12,12 @@ environment on a MacBook Pro running Mojave 10.14.6.  The basic build is tested 
 <https://github.com/gbrammer/grizli/actions>`_ continuous integration (CI) tools, but
 the current test suite does not yet test all of the full functionality of the code.
 
-Preferred installation with ``conda``/``pip``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The environment can be installed with ``pip``.  The instructions below assume
-you have ``conda`` installed, e.g., with `miniconda
-<https://docs.conda.io/en/latest/miniconda.html>`_. 
-
-Set up a ``conda`` environment
+Setting up a Local Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We recommend that ``grizli`` be installed in a new vitrual environment to minimize conflicts 
+with dependencies for other packages. Possible virtual environment managers are ``conda``, ``venv``, ``pyenv``, etc.
+Here we give example with setting up a ``conda`` environment. 
 
 - Generate a ``conda`` environment named ``grizli39`` (or anything else you prefer).
   This will just provide the base Python distribution (along with ``pip``):
@@ -37,12 +34,139 @@ Set up a ``conda`` environment
     conda activate grizli39
 
 .. note::
+
    The activation needs to be done *each time* you start a new terminal. Alternatively,
    if you want it automatically done for every new terminal, you need to put the above
    command in your ``~/.bashrc`` file.
 
-Download and set up ``grizli``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Preferred installation with pip
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The latest release of ``grizli`` can be installed with ``pip``:
+
+.. code-block:: bash
+  
+  pip install grizli
+  
+There are four available options for installing dependencies: ``jwst``, ``aws``, 
+``test`` and ``docs``. These can be installed as follows:
+
+.. code-block:: bash
+
+  pip install grizli["jwst"]
+
+or 
+
+.. code-block:: bash
+
+  pip install grizli["jwst","test"]
+
+To minimize conflict of dependencies, install only the ones that you need. 
+
+Additional dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``pip`` will install all needed dependencies with the exception of the following which
+which need to be installed separately:
+
+.. code-block:: bash
+  
+  pip install git+https://github.com/gbrammer/tristars
+  pip install pyregion
+  
+If you will be working with HST data, you will also need the following two 
+libraries:
+
+.. code-block:: bash
+
+  conda install hstcal
+  pip install git+https://github.com/gbrammer/reprocess_wfc3.git
+
+``lacosmicx``
+#############
+
+``lacosmicx`` is not required for running ``grizli``. If it is not installed, there will
+be no additional cosmic ray rejection performed. ``lacosmicx`` has been superseeded by 
+`astroscrappy <https://github.com/astropy/astroscrappy>`__
+`lacosmicx <https://github.com/cmccully/lacosmicx>`__ is a fast Python implementation of
+Pieter van Dokkum's `L.A.Cosmic <http://www.astro.yale.edu/dokkum/lacosmic/>`__
+(`2001PASP..113.1420V <http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software
+for identifying cosmic rays in single images. The image preparation wrapper scripts in
+`grizli.prep` run ``lacosmicx`` if a supplied list of direct or grism images contains
+only a single file. 
+
+- Change directories to the location where the ``grizli`` repo was cloned before:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python # location from before
+
+- Activate the ``conda`` environment:
+
+.. code-block:: bash
+
+    conda activate grizli39 # or whatever was chosen before
+
+- Fetch the ``lacosmicx`` repo, and change into its directory:
+
+.. code-block:: bash
+
+    git clone https://github.com/cmccully/lacosmicx.git
+    cd lacosmicx
+
+- Install the package into the current environment:
+
+.. code-block:: bash
+
+    python setup.py install
+
+.. note::
+    The `lacosmicx` dependency was removed from `environment.yml` file
+    2019.12.31 because it was breaking on OSX Mojave 10.14.6 with a
+    compilation error like `unsupported option '-fopenmp'`. The workaround
+    below with the Homebrew version of `gcc` may work after verifying the
+    correct path to the `gcc-8` executable:
+    
+    .. code-block:: bash
+
+        brew install gcc
+        CC=/usr/local/Cellar/gcc/10.2.0/bin/gcc-10 pip install git+https://github.com/cmccully/lacosmicx.git
+        
+``eazy-py``
+###########
+
+If you are planning to run simultaneous fits to grism spectra plus photometry using the
+`eazy-py <https://github.com/gbrammer/eazy-py>`_ connection, install ``eazy-py`` from
+the repository to ensure that you get *its* dependencies.
+
+- Change directories to the location where the ``grizli`` repo was cloned before:
+
+.. code-block:: bash
+
+    cd /usr/local/share/python # location from before
+    conda activate grizli39 # or whatever was chosen before
+
+- Fetch the ``eazy-py`` repo, change into its directory and install it. This needs to 
+only be done once, or after updating the
+  repository:
+
+.. code-block:: bash
+
+    git clone --recurse-submodules https://github.com/gbrammer/eazy-py.git
+    cd eazy-py
+    pip install -r requirements.txt .
+
+- Run basic tests with ``pytest``. Note that the ``pysynphot`` failure is not critical:
+
+.. code-block:: bash
+
+    pytest
+
+Installing ``grizli`` from source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you need to install ``grizli` form a specific branch or need an editable version 
+of the library, you can do this directly from the repository.
 
 - Change into a directory where the ``grizli`` repo will live. Instead of
   ``/usr/local/share/python``, this could even be some other location such as ``/tmp/``:
@@ -64,16 +188,15 @@ Download and set up ``grizli``
 .. code-block:: bash
 
    pip install --editable .
-
-.. note::
-   The `--editable` flag builds the Cython extensions needed for `pytest`.
-
-- Install ``hstcal``, a dependency for the WFC3/IR pipeline ``calwf3``, that doesn't
-  install with ``pip``:
+   
+Or to install the optional dependencies:
 
 .. code-block:: bash
 
-    conda install hstcal
+   pip install --editable ".[jwst,test]"
+
+
+See above for the additional dependencies that need to be installed.
 
 Set up directories and fetch additional files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,7 +244,7 @@ Set up directories and fetch additional files
 .. code-block:: python
 
     >>> import grizli.utils
-    >>> grizli.utils.symlink_templates(force=False)
+    >>> grizli.utils.symlink_templates(force=True)
     >>> # Set force=True to symlink files even if they already exist in 
     >>> # $GRIZLI/templates/.
 
@@ -132,50 +255,7 @@ Set up directories and fetch additional files
     pip install '.[test]'
     pytest
 
-Installing additional dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-``eazy-py``
-###########
-
-If you are planning to run simultaneous fits to grism spectra plus photometry using the
-`eazy-py <https://github.com/gbrammer/eazy-py>`_ connection, install ``eazy-py`` from
-the repository to ensure that you get *its* dependencies.
-
-- Change directories to the location where the ``grizli`` repo was cloned before:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python # location from before
-
-- Activate the ``conda`` environment:
-
-.. code-block:: bash
-
-    conda activate grizli39 # or whatever was chosen before
-
-- Fetch the ``eazy-py`` repo, and change into its directory:
-
-.. code-block:: bash
-
-    git clone --recurse-submodules https://github.com/gbrammer/eazy-py.git
-    cd eazy-py
-  
-- Install the ``eazy-py`` module. This needs to only be done once, or after updating the
-  repository:
-
-.. code-block:: bash
-
-    pip install -r requirements.txt .
-
-- Run basic tests with ``pytest``. Note that the ``pysynphot`` failure is not critical:
-
-.. code-block:: bash
-
-    pytest
- 
-
-Full *HST* reduction pipeline
+Using HST Files Staged on AWS
 #############################
 
 ``grizli`` can automatically pull FITS files from the public AWS S3 bucket mirror of the
@@ -200,49 +280,4 @@ requires that the AWS command line tools and the ``boto3`` module be installed:
     pip install '.[aws]'
 
 
-``lacosmicx``
-#############
 
-`lacosmicx <https://github.com/cmccully/lacosmicx>`__ is a fast Python implementation of
-Pieter van Dokkum's `L.A.Cosmic <http://www.astro.yale.edu/dokkum/lacosmic/>`__
-(`2001PASP..113.1420V <http://adsabs.harvard.edu/abs/2001PASP..113.1420V>`__) software
-for identifying cosmic rays in single images. The image preparation wrapper scripts in
-`grizli.prep` run ``lacosmicx`` if a supplied list of direct or grism images contains
-only a single file.
-
-- Change directories to the location where the ``grizli`` repo was cloned before:
-
-.. code-block:: bash
-
-    cd /usr/local/share/python # location from before
-
-- Activate the ``conda`` environment:
-
-.. code-block:: bash
-
-    conda activate grizli39 # or whatever was chosen before
-
-- Fetch the ``lacosmicx`` repo, and change into its directory:
-
-.. code-block:: bash
-
-    git clone https://github.com/cmccully/lacosmicx.git
-    cd lacosmicx
-
-- Install the package into the current environment:
-
-.. code-block:: bash
-
-    python setup.py install
-
-.. note::
-    The `lacosmicx` dependency was removed from `environment.yml` file
-    2019.12.31 because it was breaking on OSX Mojave 10.14.6 with a
-    compilation error like `unsupported option '-fopenmp'`. The workaround
-    below with the Homebrew version of `gcc` may work after verifying the
-    correct path to the `gcc-8` executable:
-    
-    .. code-block:: bash
-
-        brew install gcc
-        CC=/usr/local/Cellar/gcc/10.2.0/bin/gcc-10 pip install git+https://github.com/cmccully/lacosmicx.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ jwst =
 hst =
     hstcal
 aws =
+    awscli
     boto3
 
 [options.package_data]


### PR DESCRIPTION
PR to update the installation instructions to reflect the cleaned up install process.

Additional changes include:

- Blocks of code are now broken up and displayed with reST's `code-block` role.
- A general restructuring of the flow of the document, so that topics are nicely separated into specific headings.
- Adding `awscli` into `setup.cfg` so that `pip install .[aws]` installs _both_ `awscli` and `boto3`.


P.S: Apologies for the gigantic diff, this is due to me restricting linewidths so that text doesn't wrap!

Closes #11 