### PR TITLE
Add publish to pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,10 +3,10 @@ name: Build
 on:
   release:
     types: [released]
-  push:
-    branches:
-      - master
-  pull_request:
+  # push:
+  #   branches:
+  #     - master
+  # pull_request:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Build and Release to PyPI
+name: Build
 
 on:
   release:
@@ -7,10 +7,15 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+
+env:
+  CIBW_SKIP: pp*  # only build CPython wheels
+  CIBW_ARCHS: auto64 # don't bother with 32bit wheels
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,17 +24,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          depth: 0
+          fetch-depth: 0
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-          CIBW_SKIP: pp*
-          # CIBW_ARCHS_MACOS: "x86_64 arm64"
 
   build_sdist:
-    name: Build source distribution
+    name: source distribution
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -45,6 +48,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
+    name: upload to PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,58 @@
+name: Build and Release to PyPI
+
+on:
+  release:
+    types: [released]
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          depth: 0
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.2
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+          CIBW_SKIP: pp*
+          # CIBW_ARCHS_MACOS: "x86_64 arm64"
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build sdist
+        run: |
+          pip install build
+          python -m build --sdist
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.5.1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This workflow will run on ~every pull request, tag, and on~ Github release/publish events _and manually via workflow_dispatch_.  But it will only upload to pypi on a Github release/publish event.

It builds all 64-bit Linux and MacOS CPython wheels, and the sdist.